### PR TITLE
Include integration config in catalog.json endpoint

### DIFF
--- a/internal/api/catalogapi/v1/catalog.go
+++ b/internal/api/catalogapi/v1/catalog.go
@@ -14,7 +14,7 @@ func (e CatalogEndpoint) GetOutputPath() string { return e.outputPath }
 func (e CatalogEndpoint) GetData() interface{}  { return e.data }
 
 type Catalog struct {
-	NamespacedIntegrations map[string][]string `json:"namespaced_integrations" yaml:"namespaced_integrations"`
+	NamespacedIntegrations map[string][]IntegrationVersion `json:"namespaced_integrations" yaml:"namespaced_integrations"`
 }
 
 func NewCatalogEndpoint(basePath string, catalog Catalog) CatalogEndpoint {

--- a/internal/endpoints/catalog.go
+++ b/internal/endpoints/catalog.go
@@ -2,21 +2,12 @@ package endpoints
 
 import (
 	catalogapiv1 "github.com/sensu/catalog-api/internal/api/catalogapi/v1"
-	"github.com/sensu/catalog-api/internal/types"
 )
 
 // GET /api/:generated_sha/v1/catalog.json
-func GenerateCatalogEndpoint(basePath string, nis types.NamespacedIntegrations) error {
-	nsIntegrations := map[string][]string{}
-	for namespace, vis := range nis {
-		integrations := []string{}
-		for integration, _ := range vis {
-			integrations = append(integrations, integration)
-		}
-		nsIntegrations[namespace] = integrations
-	}
+func GenerateCatalogEndpoint(basePath string, nis map[string][]catalogapiv1.IntegrationVersion) error {
 	catalog := catalogapiv1.Catalog{
-		NamespacedIntegrations: nsIntegrations,
+		NamespacedIntegrations: nis,
 	}
 	endpoint := catalogapiv1.NewCatalogEndpoint(basePath, catalog)
 	return renderJSON(endpoint)

--- a/internal/endpoints/integration.go
+++ b/internal/endpoints/integration.go
@@ -40,14 +40,14 @@ func GenerateIntegrationVersionEndpoint(basePath string, integration catalogv1.I
 	return renderJSON(endpoint)
 }
 
-// GET /api/:generated_sha/v1/integrations/:namespace/:name/:version/resources.json
+// GET /api/:generated_sha/v1/integrations/:namespace/:name/:version/sensu-resources.json
 func GenerateIntegrationVersionResourcesEndpoint(basePath string, integration catalogv1.Integration, version types.IntegrationVersion, data string) error {
 	iv := catalogapiv1.IntegrationVersion{
 		Integration: integration,
 		Version:     version.SemVer(),
 	}
 	endpoint := catalogapiv1.NewIntegrationVersionResourcesEndpoint(basePath, iv, data)
-	return renderJSON(endpoint)
+	return renderRaw(endpoint)
 }
 
 // GET /api/:generated_sha/v1/integrations/:namespace/:name/:version/logo.png

--- a/internal/types/integration.go
+++ b/internal/types/integration.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"fmt"
+
+	"golang.org/x/mod/semver"
 )
 
 // IntegrationVersion is a representation of a single integration version
@@ -35,9 +37,27 @@ func (i IntegrationVersion) SemVer() string {
 	return version
 }
 
+type IntegrationVersionsSlice []IntegrationVersion
+
+func (v IntegrationVersionsSlice) LatestVersion() IntegrationVersion {
+	latestVersion := IntegrationVersion{}
+
+	for i, version := range v {
+		if i != 0 {
+			if semver.Compare(latestVersion.SemVer(), version.SemVer()) == -1 {
+				latestVersion = version
+			}
+		} else {
+			latestVersion = version
+		}
+	}
+
+	return latestVersion
+}
+
 // VersionedIntegrations is a mapping of integration names to
 // IntegrationVersions
-type VersionedIntegrations map[string][]IntegrationVersion
+type VersionedIntegrations map[string]IntegrationVersionsSlice
 
 // NamespacedIntegrations is a mapping of namespaces to VersionedIntegrations
 type NamespacedIntegrations map[string]VersionedIntegrations


### PR DESCRIPTION
This adds the latest version & configuration for each integration to the catalog.json endpoint.

I also snuck in a fix for the sensu-resources.json endpoints as it was being JSON marshalled twice.

Closes #9.

Example response:

```json
{
  "namespaced_integrations": {
    "nginx": [
      {
        "metadata": {
          "name": "nginx-monitoring",
          "namespace": "nginx"
        },
        "class": "community",
        "contributors": [
          "@nixwiz",
          "@calebhailey"
        ],
        "provider": "agent/check",
        "short_description": "NGINX monitoring",
        "supported_platforms": [
          "darwin",
          "linux",
          "windows"
        ],
        "tags": [
          "http",
          "nginx",
          "webserver"
        ],
        "version": "20220125.0.0"
      }
    ],
    "system": [
      {
        "metadata": {
          "name": "host-monitoring",
          "namespace": "system"
        },
        "class": "supported",
        "contributors": [
          "@sensu",
          "@calebhailey",
          "@nixwiz",
          "@jspaleta",
          "@thoward"
        ],
        "provider": "agent/check",
        "short_description": "Host monitoring",
        "supported_platforms": [
          "darwin",
          "linux",
          "windows"
        ],
        "tags": [
          "system",
          "host",
          "os",
          "windows",
          "linux",
          "macos",
          "cpu",
          "memory",
          "io",
          "load",
          "uptime",
          "swap"
        ],
        "version": "20220125.0.0"
      }
    ]
  }
}
```