### PR TITLE
Add dev-server to help preview catalog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
+require github.com/gorilla/websocket v1.5.0 // indirect
+
 require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -108,6 +110,7 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/internal/catalogserver/handler.go
+++ b/internal/catalogserver/handler.go
@@ -1,0 +1,44 @@
+package catalogserver
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
+	"github.com/sensu/catalog-api/internal/transport"
+)
+
+type handler struct {
+	transport *transport.Transport
+	symlink   string
+}
+
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/ws":
+		h.serveWs(w, r)
+	default:
+		// allow cross domain AJAX requests
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		// disable caching of served files
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0")
+
+		http.FileServer(http.Dir(h.symlink)).ServeHTTP(w, r)
+	}
+}
+
+func (h handler) serveWs(w http.ResponseWriter, r *http.Request) {
+	log.Info().Str("remote_addr", r.RemoteAddr).Msg("WebSocket client connected")
+
+	upgrader := websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Info().Err(err).Msg("WebSocket upgrade failed")
+		return
+	}
+
+	client := transport.NewClient(h.transport, conn)
+	h.transport.Register(&client)
+	go client.WritePump()
+}

--- a/internal/catalogserver/server.go
+++ b/internal/catalogserver/server.go
@@ -1,0 +1,61 @@
+package catalogserver
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"github.com/sensu/catalog-api/internal/transport"
+)
+
+type CatalogServer struct {
+	server    *http.Server
+	symlink   string
+	transport *transport.Transport
+}
+
+func NewCatalogServer(listenAddr string, symlink string) CatalogServer {
+	t := transport.NewTransport()
+
+	handler := &handler{
+		symlink:   symlink,
+		transport: &t,
+	}
+
+	server := &http.Server{
+		Addr:    listenAddr,
+		Handler: handler,
+	}
+
+	return CatalogServer{
+		server:    server,
+		symlink:   symlink,
+		transport: &t,
+	}
+}
+
+func (c *CatalogServer) Start(ctx context.Context) {
+	// start the transport server
+	go c.transport.Start(ctx)
+
+	// start the tcp listener
+	listener, err := net.Listen("tcp", c.server.Addr)
+	if err != nil {
+		panic(err)
+	}
+	log.Info().Str("address", c.server.Addr).Msg("API server started")
+
+	// serve http requests over the tcp listener
+	if err := c.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		panic(err)
+	}
+}
+
+func (c *CatalogServer) Stop(ctx context.Context) error {
+	return c.server.Shutdown(ctx)
+}
+
+func (c *CatalogServer) HandleWatchEvent() {
+	c.transport.Broadcast([]byte("refresh"))
+}

--- a/internal/commands/catalogcmd/cmd.go
+++ b/internal/commands/catalogcmd/cmd.go
@@ -25,6 +25,7 @@ type Config struct {
 	tempDir             string
 	integrationsDirName string
 	snapshot            bool
+	watch               bool
 }
 
 func New(rootConfig rootcmd.Config) *ffcli.Command {

--- a/internal/commands/catalogcmd/generate.go
+++ b/internal/commands/catalogcmd/generate.go
@@ -56,7 +56,7 @@ func (c *Config) execGenerateWatcher(ctx context.Context) error {
 	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
 
 	// setup file-system notifications
-	watcher, err := c.watchRepo(ctx)
+	watcher, err := c.createWatcher(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/catalogcmd/generate.go
+++ b/internal/commands/catalogcmd/generate.go
@@ -8,11 +8,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/fsnotify/fsnotify"
-	"github.com/go-git/go-git/v5"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/rs/zerolog/log"
-	"github.com/sensu/catalog-api/internal/catalogloader"
 )
 
 func (c *Config) GenerateCommand() *ffcli.Command {
@@ -35,8 +32,8 @@ func (c *Config) GenerateCommand() *ffcli.Command {
 
 func (c *Config) RegisterGenerateFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.tempDir, "temp-dir", defaultTempDir, "path to a temporary directory for generated files")
-	fs.BoolVar(&c.snapshot, "snapshot", false, "generate a catalog api for the current catalog branch")
-	fs.BoolVar(&c.watch, "watch", false, "enter watch mode, which rebuilds on file change")
+	fs.BoolVar(&c.snapshot, "snapshot", defaultSnapshot, "generate a catalog api for the current catalog branch")
+	fs.BoolVar(&c.watch, "watch", defaultWatchMode, "enter watch mode, which rebuilds on file change")
 }
 
 func (c *Config) execGenerate(ctx context.Context, _ []string) error {
@@ -48,37 +45,44 @@ func (c *Config) execGenerate(ctx context.Context, _ []string) error {
 
 func (c *Config) execGenerateWatcher(ctx context.Context) error {
 	// produce initial build
-	if err := c.execRunGenerate(ctx); err != nil {
+	outdir, err := c.generate(ctx)
+	if err != nil {
 		return err
 	}
+	log.Info().Msgf("outdir: %s", outdir)
 
 	// configure channel for exit signal
 	exit := make(chan os.Signal, 1)
 	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
 
 	// setup file-system notifications
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := c.watchRepo(ctx)
 	if err != nil {
-		return fmt.Errorf("error configuring watcher: %w", err)
+		return err
 	}
 	defer watcher.Close()
-	if err := watcher.Add(c.repoDir); err != nil {
-		return fmt.Errorf("error watching repo dir: %w", err)
-	}
-	log.Info().Msg("watching repo for changes")
 
 	// wait on fs events or exit signal
 	for {
+		lastOutdir := outdir
 		select {
 		case _, ok := <-watcher.Events:
 			if !ok {
 				return nil
 			}
-			log.Info().Msg("update detected, rebuilding...")
-			err = c.execRunGenerate(ctx)
+
+			log.Debug().Msg("update detected, rebuilding...")
+			outdir, err = c.generate(ctx)
 			if err != nil {
 				log.Error().Err(err)
 			}
+
+			log.Debug().Msgf("deleting last tmpdir: %s", lastOutdir)
+			if err := os.RemoveAll(lastOutdir); err != nil {
+				log.Error().Err(err)
+			}
+
+			log.Info().Msgf("new outdir: %s", outdir)
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return nil
@@ -91,32 +95,14 @@ func (c *Config) execGenerateWatcher(ctx context.Context) error {
 }
 
 func (c *Config) execRunGenerate(ctx context.Context) error {
-	repo, err := git.PlainOpen(c.repoDir)
+	outdir, err := c.generate(ctx)
 	if err != nil {
 		return err
-	}
-
-	var loader catalogloader.Loader
-	if c.snapshot {
-		loader = catalogloader.NewSnapshotLoader(repo, c.repoDir, c.integrationsDirName)
-	} else {
-		loader = catalogloader.NewGitLoader(repo, c.integrationsDirName)
-	}
-
-	cm, err := c.newCatalogManager(loader)
-	if err != nil {
-		return err
-	}
-
-	// process the catalog & all its integrations
-	if err := cm.ProcessCatalog(); err != nil {
-		return fmt.Errorf("error processing catalog: %w", err)
 	}
 
 	// print outputs for github actions
 	// TODO(jk): enable this with a command flag,
 	// e.g. --with-github-action-outputs
-	fmt.Printf("::set-output name=release-dir::%s\n", cm.GetConfig().ReleaseDir)
-
+	fmt.Printf("::set-output name=release-dir::%s\n", outdir)
 	return nil
 }

--- a/internal/commands/catalogcmd/generate.go
+++ b/internal/commands/catalogcmd/generate.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-git/go-git/v5"
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rs/zerolog/log"
 	"github.com/sensu/catalog-api/internal/catalogloader"
 )
 
@@ -31,9 +36,61 @@ func (c *Config) GenerateCommand() *ffcli.Command {
 func (c *Config) RegisterGenerateFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.tempDir, "temp-dir", defaultTempDir, "path to a temporary directory for generated files")
 	fs.BoolVar(&c.snapshot, "snapshot", false, "generate a catalog api for the current catalog branch")
+	fs.BoolVar(&c.watch, "watch", false, "enter watch mode, which rebuilds on file change")
 }
 
 func (c *Config) execGenerate(ctx context.Context, _ []string) error {
+	if c.watch {
+		return c.execGenerateWatcher(ctx)
+	}
+	return c.execRunGenerate(ctx)
+}
+
+func (c *Config) execGenerateWatcher(ctx context.Context) error {
+	// produce initial build
+	if err := c.execRunGenerate(ctx); err != nil {
+		return err
+	}
+
+	// configure channel for exit signal
+	exit := make(chan os.Signal, 1)
+	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+
+	// setup file-system notifications
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("error configuring watcher: %w", err)
+	}
+	defer watcher.Close()
+	if err := watcher.Add(c.repoDir); err != nil {
+		return fmt.Errorf("error watching repo dir: %w", err)
+	}
+	log.Info().Msg("watching repo for changes")
+
+	// wait on fs events or exit signal
+	for {
+		select {
+		case _, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			log.Info().Msg("update detected, rebuilding...")
+			err = c.execRunGenerate(ctx)
+			if err != nil {
+				log.Error().Err(err)
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			log.Error().Err(err)
+		case <-exit:
+			return nil
+		}
+	}
+}
+
+func (c *Config) execRunGenerate(ctx context.Context) error {
 	repo, err := git.PlainOpen(c.repoDir)
 	if err != nil {
 		return err

--- a/internal/commands/catalogcmd/server.go
+++ b/internal/commands/catalogcmd/server.go
@@ -57,7 +57,9 @@ func (c *Config) startServer(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	defer cleanup()
+	defer func() {
+		cleanup() // inside closure to ensure we deref the correct func
+	}()
 
 	// watch
 	if c.watch {
@@ -153,7 +155,9 @@ func (c *Config) prepare(ctx context.Context, symlink string) (cleanup func(), e
 	if err := os.Symlink(filepath.Join(cm.tmpdir, "release"), symlink); err != nil {
 		return cleanup, err
 	}
+	log.Info().Msgf("api prepared: %s", cm.tmpdir)
 	return func() {
+		log.Warn().Msgf("cleaning up tmp dir: %s", cm.tmpdir)
 		_ = os.RemoveAll(cm.tmpdir)
 		_ = os.RemoveAll(symlink)
 	}, err

--- a/internal/commands/catalogcmd/server.go
+++ b/internal/commands/catalogcmd/server.go
@@ -40,11 +40,14 @@ func (c *Config) ServerCommand() *ffcli.Command {
 func (c *Config) RegisterServerFlags(fs *flag.FlagSet) {
 	fs.IntVar(&c.port, "port", defaultServerPort, "port to use for dev server")
 	fs.StringVar(&c.tempDir, "temp-dir", defaultTempDir, "path to a temporary directory for generated files")
-	fs.BoolVar(&c.snapshot, "snapshot", defaultSnapshot, "generate a catalog api for the current catalog branch")
+	fs.BoolVar(&c.snapshot, "without-snapshot", defaultSnapshot, "generate a catalog api using tags only")
 	fs.BoolVar(&c.watch, "watch", defaultWatchMode, "enter watch mode, which rebuilds on file change")
 }
 
 func (c *Config) execServer(ctx context.Context, _ []string) error {
+	// treat snapshot as if it were without-snapshot
+	c.snapshot = !c.snapshot
+
 	return c.startServer(ctx)
 }
 

--- a/internal/commands/catalogcmd/server.go
+++ b/internal/commands/catalogcmd/server.go
@@ -1,0 +1,105 @@
+package catalogcmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultServerPort = 8083
+)
+
+func (c *Config) ServerCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("catalog-api catalog server", flag.ExitOnError)
+
+	// register catalog generate flags
+	c.RegisterServerFlags(fs)
+
+	// register catalog & global flags
+	c.RegisterFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "server",
+		ShortUsage: "catalog-api catalog server [flags]",
+		ShortHelp:  "Serves static catalog API for development purposes",
+		FlagSet:    fs,
+		Exec:       c.rootConfig.PreExec(c.execServer),
+	}
+}
+
+func (c *Config) RegisterServerFlags(fs *flag.FlagSet) {
+	fs.IntVar(&c.port, "port", defaultServerPort, "port to use for dev server")
+	fs.StringVar(&c.tempDir, "temp-dir", defaultTempDir, "path to a temporary directory for generated files")
+	fs.BoolVar(&c.snapshot, "snapshot", defaultSnapshot, "generate a catalog api for the current catalog branch")
+	fs.BoolVar(&c.watch, "watch", defaultWatchMode, "enter watch mode, which rebuilds on file change")
+}
+
+func (c *Config) execServer(ctx context.Context, _ []string) error {
+	if c.watch {
+		return c.startServerWatcher(ctx)
+	}
+	return c.startServer(ctx)
+}
+
+func (c *Config) startServerWatcher(ctx context.Context) error {
+	// ...
+	return nil
+}
+
+func (c *Config) startServer(ctx context.Context) error {
+	// configure
+	cm, outdir, err := c.newCatalogManagerFromRepo(ctx)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(outdir)
+
+	// generate
+	if err := cm.ProcessCatalog(); err != nil {
+		return err
+	}
+
+	// validate
+	if err := cm.ValidateCatalog(); err != nil {
+		log.Warn().Err(err)
+	}
+
+	// symlink
+	symdir := filepath.Join(c.tempDir, "current")
+	if err := os.RemoveAll(symdir); err != nil {
+		return err
+	}
+	if err := os.Symlink(filepath.Join(outdir, "release"), symdir); err != nil {
+		return err
+	}
+	defer os.RemoveAll(symdir)
+
+	// start server
+	router := http.FileServer(http.Dir(symdir))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", c.port),
+		Handler: router,
+	}
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			panic(err)
+		}
+	}()
+
+	// configure channel for exit signal
+	exit := make(chan os.Signal, 1)
+	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+
+	<-exit
+	return server.Shutdown(ctx)
+}

--- a/internal/commands/catalogcmd/shared.go
+++ b/internal/commands/catalogcmd/shared.go
@@ -1,0 +1,52 @@
+package catalogcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-git/go-git/v5"
+	"github.com/rs/zerolog/log"
+	"github.com/sensu/catalog-api/internal/catalogloader"
+	"github.com/sensu/catalog-api/internal/catalogmanager"
+)
+
+func (c *Config) newCatalogManagerFromRepo(ctx context.Context) (catalogmanager.CatalogManager, string, error) {
+	var cm catalogmanager.CatalogManager
+
+	repo, err := git.PlainOpen(c.repoDir)
+	if err != nil {
+		return cm, "", err
+	}
+
+	var loader catalogloader.Loader
+	if c.snapshot {
+		loader = catalogloader.NewSnapshotLoader(repo, c.repoDir, c.integrationsDirName)
+	} else {
+		loader = catalogloader.NewGitLoader(repo, c.integrationsDirName)
+	}
+	return c.newCatalogManager(loader)
+}
+
+func (c *Config) generate(ctx context.Context) (string, error) {
+	cm, outdir, err := c.newCatalogManagerFromRepo(ctx)
+	if err != nil {
+		return outdir, err
+	}
+
+	// process the catalog & all its integrations
+	err = cm.ProcessCatalog()
+	return outdir, err
+}
+
+func (c *Config) watchRepo(ctx context.Context) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return watcher, fmt.Errorf("error configuring watcher: %w", err)
+	}
+	if err := watcher.Add(c.repoDir); err != nil {
+		return watcher, fmt.Errorf("error watching repo dir: %w", err)
+	}
+	log.Info().Msg("watching repo for changes")
+	return watcher, err
+}

--- a/internal/commands/catalogcmd/shared.go
+++ b/internal/commands/catalogcmd/shared.go
@@ -90,6 +90,16 @@ func (c *Config) createWatcher(ctx context.Context) (*fsnotify.Watcher, error) {
 	if err != nil {
 		return watcher, fmt.Errorf("error configuring watcher: %w", err)
 	}
+	dir := filepath.Join(c.repoDir, "integrations")
+	walker := func(path string, fi os.FileInfo, err error) error {
+		if fi.Mode().IsDir() {
+			return watcher.Add(path)
+		}
+		return nil
+	}
+	if err := filepath.Walk(dir, walker); err != nil {
+		return watcher, fmt.Errorf("error adding paths to watcher: %w", err)
+	}
 	if err := watcher.Add(c.repoDir); err != nil {
 		return watcher, fmt.Errorf("error watching repo dir: %w", err)
 	}

--- a/internal/commands/catalogcmd/shared.go
+++ b/internal/commands/catalogcmd/shared.go
@@ -3,20 +3,66 @@ package catalogcmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-git/go-git/v5"
-	"github.com/rs/zerolog/log"
 	"github.com/sensu/catalog-api/internal/catalogloader"
 	"github.com/sensu/catalog-api/internal/catalogmanager"
 )
 
-func (c *Config) newCatalogManagerFromRepo(ctx context.Context) (catalogmanager.CatalogManager, string, error) {
-	var cm catalogmanager.CatalogManager
+type catalogManager interface {
+	ProcessCatalog() error
+	Validate() error
+}
 
+type tmpCatalogManager struct {
+	catalogmanager.CatalogManager
+	tmpdir string
+}
+
+func (c *Config) newCatalogManager(loader catalogloader.Loader) (cm tmpCatalogManager, err error) {
+	// create a temporay directory within c.tempDir to hold the generated api
+	// files
+	cm.tmpdir, err = os.MkdirTemp(c.tempDir, "")
+	if err != nil {
+		return cm, fmt.Errorf("error creating temp directory: %w", err)
+	}
+	cm.tmpdir, err = filepath.Abs(cm.tmpdir)
+	if err != nil {
+		return cm, err
+	}
+
+	// create a staging dir to hold the generated api files used to calculate
+	// the checksum of the release
+	stagingDir := path.Join(cm.tmpdir, "staging")
+	if err := os.Mkdir(stagingDir, 0700); err != nil {
+		return cm, fmt.Errorf("error creating staging directory: %w", err)
+	}
+
+	// create a release dir to hold the complete set of generated api files
+	releaseDir := path.Join(cm.tmpdir, "release")
+	if err := os.Mkdir(releaseDir, 0700); err != nil {
+		return cm, fmt.Errorf("error creating release directory: %w", err)
+	}
+
+	mCfg := catalogmanager.Config{
+		StagingDir: stagingDir,
+		ReleaseDir: releaseDir,
+	}
+
+	// create a new catalog manager which is used to determine versions from git
+	// tags, unmarshal resources, and generate the api
+	cm.CatalogManager, err = catalogmanager.New(mCfg, loader)
+	return cm, err
+}
+
+func (c *Config) newCatalogManagerFromRepo(ctx context.Context) (cm tmpCatalogManager, err error) {
 	repo, err := git.PlainOpen(c.repoDir)
 	if err != nil {
-		return cm, "", err
+		return cm, err
 	}
 
 	var loader catalogloader.Loader
@@ -29,17 +75,17 @@ func (c *Config) newCatalogManagerFromRepo(ctx context.Context) (catalogmanager.
 }
 
 func (c *Config) generate(ctx context.Context) (string, error) {
-	cm, outdir, err := c.newCatalogManagerFromRepo(ctx)
+	cm, err := c.newCatalogManagerFromRepo(ctx)
 	if err != nil {
-		return outdir, err
+		return cm.tmpdir, err
 	}
 
 	// process the catalog & all its integrations
 	err = cm.ProcessCatalog()
-	return outdir, err
+	return cm.tmpdir, err
 }
 
-func (c *Config) watchRepo(ctx context.Context) (*fsnotify.Watcher, error) {
+func (c *Config) createWatcher(ctx context.Context) (*fsnotify.Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return watcher, fmt.Errorf("error configuring watcher: %w", err)
@@ -47,6 +93,5 @@ func (c *Config) watchRepo(ctx context.Context) (*fsnotify.Watcher, error) {
 	if err := watcher.Add(c.repoDir); err != nil {
 		return watcher, fmt.Errorf("error watching repo dir: %w", err)
 	}
-	log.Info().Msg("watching repo for changes")
 	return watcher, err
 }

--- a/internal/commands/catalogcmd/shared.go
+++ b/internal/commands/catalogcmd/shared.go
@@ -91,13 +91,13 @@ func (c *Config) createWatcher(ctx context.Context) (*fsnotify.Watcher, error) {
 		return watcher, fmt.Errorf("error configuring watcher: %w", err)
 	}
 	dir := filepath.Join(c.repoDir, "integrations")
-	walker := func(path string, fi os.FileInfo, err error) error {
-		if fi.Mode().IsDir() {
+	walker := func(path string, de os.DirEntry, err error) error {
+		if de.Type().IsDir() {
 			return watcher.Add(path)
 		}
 		return nil
 	}
-	if err := filepath.Walk(dir, walker); err != nil {
+	if err := filepath.WalkDir(dir, walker); err != nil {
 		return watcher, fmt.Errorf("error adding paths to watcher: %w", err)
 	}
 	if err := watcher.Add(c.repoDir); err != nil {

--- a/internal/commands/catalogcmd/validate.go
+++ b/internal/commands/catalogcmd/validate.go
@@ -27,7 +27,7 @@ func (c *Config) ValidateCommand() *ffcli.Command {
 func (c *Config) execValidate(context.Context, []string) error {
 	loader := catalogloader.NewPathLoader(c.repoDir, c.integrationsDirName)
 
-	cm, _, err := c.newCatalogManager(loader)
+	cm, err := c.newCatalogManager(loader)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/catalogcmd/validate.go
+++ b/internal/commands/catalogcmd/validate.go
@@ -27,7 +27,7 @@ func (c *Config) ValidateCommand() *ffcli.Command {
 func (c *Config) execValidate(context.Context, []string) error {
 	loader := catalogloader.NewPathLoader(c.repoDir, c.integrationsDirName)
 
-	cm, err := c.newCatalogManager(loader)
+	cm, _, err := c.newCatalogManager(loader)
 	if err != nil {
 		return err
 	}

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -1,0 +1,72 @@
+package transport
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	pingInterval = 30 * time.Second
+	pongWait     = 60 * time.Second
+	writeWait    = 10 * time.Second
+)
+
+var (
+	newline = []byte{'\n'}
+	space   = []byte{' '}
+)
+
+type Client struct {
+	transport *Transport
+	conn      *websocket.Conn
+	send      chan []byte
+}
+
+func NewClient(t *Transport, conn *websocket.Conn) Client {
+	return Client{
+		transport: t,
+		conn:      conn,
+		send:      make(chan []byte, 256),
+	}
+}
+
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingInterval)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			w.Write(message)
+
+			n := len(c.send)
+			for i := 0; i < n; i++ {
+				w.Write(newline)
+				w.Write(<-c.send)
+			}
+
+			if err := w.Close(); err != nil {
+				return
+			}
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,46 @@
+package transport
+
+import (
+	"context"
+)
+
+type Transport struct {
+	clients    map[*Client]bool
+	broadcast  chan []byte
+	register   chan *Client
+	unregister chan *Client
+}
+
+func NewTransport() Transport {
+	return Transport{
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		clients:    make(map[*Client]bool),
+	}
+}
+
+func (t *Transport) Broadcast(msg []byte) {
+	for client, connected := range t.clients {
+		if connected {
+			client.send <- msg
+		}
+	}
+}
+
+func (t *Transport) Register(client *Client) {
+	t.register <- client
+}
+
+func (t *Transport) Start(ctx context.Context) {
+	for {
+		select {
+		case client := <-t.register:
+			t.clients[client] = true
+		case client := <-t.unregister:
+			if _, ok := t.clients[client]; ok {
+				delete(t.clients, client)
+				close(client.send)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Works toward completing https://github.com/sensu/sensu-enterprise-go/pull/2082.

### Usage

```sh
# optionally watch file system for updates
catalog-api catalog generate --repo-dir ../catalog --watch

# dev server
catalog-api catalog server --repo-dir ../catalog

# one can optionally watch w/ dev server too
catalog-api catalog server --repo-dir ../catalog --watch
```

### Drawbacks

Originally, I had hoped to use a virtual file-system for processing and serving the assets, however I realized it was going to require a bit more refactoring than I wanted to do. Considering the resulting API is ~150MBs, I would recommend mounting a RAM disk and using the `--temp-dir` flag.
