### PR TITLE
Add annotations & labels to metadata type

### DIFF
--- a/internal/api/metadata/v1/metadata.go
+++ b/internal/api/metadata/v1/metadata.go
@@ -1,8 +1,10 @@
 package metadatav1
 
 type Metadata struct {
-	Name      string `json:"name" yaml:"name"`
-	Namespace string `json:"namespace" yaml:"namespace"`
+	Name        string            `json:"name" yaml:"name"`
+	Namespace   string            `json:"namespace" yaml:"namespace"`
+	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 func FixtureMetadata(namespace, name string) Metadata {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Closes #49.

I manually verified that annotations & labels show up in the various endpoints after adding labels & annotations to a `sensu-integration.yaml` file.